### PR TITLE
Renamed 404 page wrapper CSS ID so that it doesn't start with a number.

### DIFF
--- a/404.php
+++ b/404.php
@@ -5,7 +5,7 @@
  */
 
 get_header(); ?>
-<div class="wrapper" id="404-wrapper">
+<div class="wrapper" id="error-404-wrapper">
     
     <div  id="content" class="container">
 

--- a/page-templates/fullwidthpage.php
+++ b/page-templates/fullwidthpage.php
@@ -12,29 +12,33 @@ get_header(); ?>
 <div class="wrapper" id="full-width-page-wrapper">
     
     <div  id="content" class="container">
+    
+	   <div class="row">
         
-	   <div id="primary" class="col-md-12 content-area">
+		   <div id="primary" class="col-md-12 content-area">
 
-            <main id="main" class="site-main" role="main">
+				<main id="main" class="site-main" role="main">
 
-                <?php while ( have_posts() ) : the_post(); ?>
+					<?php while ( have_posts() ) : the_post(); ?>
 
-                    <?php get_template_part( 'loop-templates/content', 'page' ); ?>
+						<?php get_template_part( 'loop-templates/content', 'page' ); ?>
 
-                    <?php
-                        // If comments are open or we have at least one comment, load up the comment template
-                        if ( comments_open() || get_comments_number() ) :
+						<?php
+							// If comments are open or we have at least one comment, load up the comment template
+							if ( comments_open() || get_comments_number() ) :
 
-                            comments_template();
-                        
-                        endif;
-                    ?>
+								comments_template();
+						
+							endif;
+						?>
 
-                <?php endwhile; // end of the loop. ?>
+					<?php endwhile; // end of the loop. ?>
 
-            </main><!-- #main -->
-           
-	    </div><!-- #primary -->
+				</main><!-- #main -->
+		   
+			</div><!-- #primary -->
+			
+		</div><!-- #row -->
         
     </div><!-- Container end -->
     


### PR DESCRIPTION
The 404.php template page has  a CSS ID that starts with a number. CSS IDs that starts with a number cannot be used as CSS selectors making it impossible to style the page. 
